### PR TITLE
Support metric keys with multiple metric types

### DIFF
--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -281,7 +281,7 @@ func TestSample(t *testing.T) {
 
 func TestExtract(t *testing.T) {
 	ss := newTestSink(0*time.Second, nil)
-	ss.extractor = func(key []string) ([]string, []metrics.Label, error) {
+	ss.extractor = func(key []string, kind string) ([]string, []metrics.Label, error) {
 		return key[:1], []metrics.Label{
 			{
 				Name:  "method",

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -21,14 +21,14 @@ import "github.com/armon/go-metrics"
 // Extractor extracts known patterns from the key into metrics.Label for better metric grouping
 // and to help avoid the limit of 500 custom metric descriptors per project
 // (https://cloud.google.com/monitoring/quotas).
-func Extractor(key []string) ([]string, []metrics.Label, error) {
+func Extractor(key []string, kind string) ([]string, []metrics.Label, error) {
 	// Metrics documented at https://www.vaultproject.io/docs/internals/telemetry.html should be
 	// extracted here into a base metric name with appropriate labels extracted from the 'key'.
 	switch len(key) {
 	case 3: // metrics of format: *.*.*
 		// vault.database.<method>
 		if key[0] == "vault" && key[1] == "database" {
-			return key[:2], []metrics.Label{
+			return typeWrap(key[:2], kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[2],
@@ -37,14 +37,14 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		// vault.token.create_root
 		if key[0] == "vault" && key[1] == "token" && key[2] == "create_root" {
-			return key, nil, nil
+			return typeWrap(key, kind), nil, nil
 		}
 
 		// vault.barrier.<method>
 		// vault.token.<method>
 		// vault.policy.<method>
 		if key[0] == "vault" && (key[1] == "barrier" || key[1] == "token" || key[1] == "policy") {
-			return key[:2], []metrics.Label{
+			return typeWrap(key[:2], kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[2],
@@ -53,7 +53,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		// vault.<backend>.<method>
 		if key[0] == "vault" && (key[2] == "put" || key[2] == "get" || key[2] == "delete" || key[2] == "list") {
-			return key[:2], []metrics.Label{
+			return typeWrap(key[:2], kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[2],
@@ -63,7 +63,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 	case 4: // metrics of format: *.*.*.*
 		// vault.route.<method>.<mount>
 		if key[0] == "vault" && key[1] == "route" {
-			return key[:2], []metrics.Label{
+			return typeWrap(key[:2], kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[2],
@@ -76,7 +76,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		// vault.audit.<type>.*
 		if key[0] == "vault" && key[1] == "audit" {
-			return []string{"vault", "audit", key[3]}, []metrics.Label{
+			return typeWrap([]string{"vault", "audit", key[3]}, kind), []metrics.Label{
 				{
 					Name:  "type",
 					Value: key[2],
@@ -85,7 +85,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		// vault.rollback.attempt.<mount>
 		if key[0] == "vault" && key[1] == "rollback" && key[2] == "attempt" {
-			return key[:3], []metrics.Label{
+			return typeWrap(key[:3], kind), []metrics.Label{
 				{
 					Name:  "mount",
 					Value: key[3],
@@ -94,7 +94,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		// vault.<backend>.lock.<method>
 		if key[0] == "vault" && key[2] == "lock" {
-			return key[:3], []metrics.Label{
+			return typeWrap(key[:3], kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[3],
@@ -104,7 +104,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		// vault.database.<name>.<method>
 		// note: there are vault.database.<method>.error counters. Those are handled separately.
 		if key[0] == "vault" && key[1] == "database" && key[3] != "error" {
-			return key[:2], []metrics.Label{
+			return typeWrap(key[:2], kind), []metrics.Label{
 				{
 					Name:  "name",
 					Value: key[2],
@@ -117,7 +117,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 		}
 		//ivault.database.<method>.error
 		if key[0] == "vault" && key[1] == "database" && key[3] == "error" {
-			return []string{"vault", "database", "error"}, []metrics.Label{
+			return typeWrap([]string{"vault", "database", "error"}, kind), []metrics.Label{
 				{
 					Name:  "method",
 					Value: key[2],
@@ -127,7 +127,7 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 	case 5:
 		// vault.database.<name>.<method>.error
 		if key[0] == "vault" && key[1] == "database" && key[4] == "error" {
-			return []string{key[0], key[1], key[4]}, []metrics.Label{
+			return typeWrap([]string{key[0], key[1], key[4]}, kind), []metrics.Label{
 				{
 					Name:  "name",
 					Value: key[2],
@@ -141,7 +141,22 @@ func Extractor(key []string) ([]string, []metrics.Label, error) {
 	default:
 		// unknown key pattern, keep it as-is.
 	}
-	return key, nil, nil
+	return typeWrap(key, kind), nil, nil
+}
+
+func typeWrap(key []string, kind string) []string {
+	out := []string{}
+	for _, a := range key {
+		out = append(out, a)
+	}
+	switch kind {
+	case "counter":
+		return append(out, kind)
+	case "gauge":
+		return append(out, kind)
+	default:
+		return out
+	}
 }
 
 // Bucketer specifies the bucket boundaries that should be used for the given metric key.

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -1352,7 +1352,26 @@ func TestExtractor(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			key, labels, _ := Extractor(tc.in)
+			// counter
+			key, labels, _ := Extractor(tc.in, "counter")
+			if diff := cmp.Diff(append(tc.wantKey, "counter"), key); diff != "" {
+				t.Errorf("Extractor(%s) mismatch key (-want +got):\n%s", tc.in, diff)
+			}
+			if diff := cmp.Diff(tc.wantLabels, labels); diff != "" {
+				t.Errorf("Extractor(%s) mismatch labels (-want +got):\n%s", tc.in, diff)
+			}
+
+			// gauge
+			key, labels, _ = Extractor(tc.in, "gauge")
+			if diff := cmp.Diff(append(tc.wantKey, "gauge"), key); diff != "" {
+				t.Errorf("Extractor(%s) mismatch key (-want +got):\n%s", tc.in, diff)
+			}
+			if diff := cmp.Diff(tc.wantLabels, labels); diff != "" {
+				t.Errorf("Extractor(%s) mismatch labels (-want +got):\n%s", tc.in, diff)
+			}
+
+			// histogram
+			key, labels, _ = Extractor(tc.in, "histogram")
 			if diff := cmp.Diff(tc.wantKey, key); diff != "" {
 				t.Errorf("Extractor(%s) mismatch key (-want +got):\n%s", tc.in, diff)
 			}


### PR DESCRIPTION
go-metrics allows the same key to be used for multiple metric types
(gauge + histogram for example). Specifically vault exports
vault.database.CreateUser as both a histogram and a counter.

This expands ExtractLabelsFn hook to take the metric type in as a
parameter and will append "counter" or "gauge" to the end of the metric
name to avoid collisions.