### PR TITLE
Fix test case for prefix

### DIFF
--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -107,8 +107,8 @@ func TestNewSinkSetCustomPrefix(t *testing.T) {
 		},
 		{
 			name:           "set custom",
-			configPrefix:   sPtr("cuSt0m_metrics"),
-			expectedPrefix: "cuSt0m_metrics",
+			configPrefix:   sPtr("cust0m_metrics"),
+			expectedPrefix: "cust0m_metrics",
 		},
 		{
 			name:           "default to go-metrics/ when given prefix is invalid",


### PR DESCRIPTION
Realized the test case wasn't passing in https://github.com/google/go-metrics-stackdriver/pull/8 due to not matching on upper-case letters.