### PR TITLE
Update import to use v2 of cloud.google.com/go/monitoring/apiv3

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -26,7 +26,7 @@ import (
 	stackdriver "github.com/google/go-metrics-stackdriver"
 
 	"cloud.google.com/go/compute/metadata"
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	metrics "github.com/armon/go-metrics"
 )
 
@@ -58,7 +58,7 @@ func main() {
 	})
 	cfg := metrics.DefaultConfig("go-metrics-stackdriver")
 	cfg.EnableHostname = false
-	metrics.NewGlobal(metrics.DefaultConfig("go-metrics-stackdriver"), ss)
+	metrics.NewGlobal(cfg, ss)
 
 	// start listener
 	log.Printf("starting server")

--- a/stackdriver.go
+++ b/stackdriver.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	metrics "github.com/armon/go-metrics"
 	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"


### PR DESCRIPTION
v1 is now deprecated and this causes errors in some linters

This is considered a breaking change as NewSink() accepts v1 as a parameter