### PR TITLE
Record counters as CUMULATIVE metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ This package is intended as a way to publish metrics for applications that are _
 
 ## 🚨 Upgrading
 
-Between v0.5.0 and v0.6.0, the behavior of the `IncrCounter` method changed: previously it would create a `GAUGE` [metric kind](https://cloud.google.com/monitoring/api/v3/kinds-and-types), but from v0.6.0 forward it will create a `CUMULATIVE` metric kind.  (See https://github.com/google/go-metrics-stackdriver/issues/18 for a discussion.)
+Between v0.5.0 and v0.6.0, the behavior of the `IncrCounter()` method changed: previously it would create a `GAUGE` [metric kind](https://cloud.google.com/monitoring/api/v3/kinds-and-types), but from v0.6.0 forward it will create a `CUMULATIVE` metric kind.  (See https://github.com/google/go-metrics-stackdriver/issues/18 for a discussion.)
 
-However, once a [MetricDescriptor](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics#MetricDescriptor) has been created in Google Cloud Monitoring, its `metricKind` field cannot be changed.  So if you have any _existing_ `GAUGE` metrics that were created by `IncrCounter`, you will see errors in your logs when the v0.6.0 client attempts to update them and fails.  Your options for handling this are:
+However, once a [MetricDescriptor](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics#MetricDescriptor) has been created in Google Cloud Monitoring, its `metricKind` field cannot be changed.  So if you have any _existing_ `GAUGE` metrics that were created by `IncrCounter()`, you will see errors in your logs when the v0.6.0 client attempts to update them and fails.  Your options for handling this are:
 
 1. Change the name of the metric you are passing to `IncrCounter` (creating a new metricDescriptor with a different name), or:
 2. Delete the existing metricDescriptor using the [delete API](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors/delete) and let go-metrics re-create it as a `CUMULATIVE` metric
+
+Additionally, v0.6.0 adds `ResetCounter()` and `ResetCounterWithLabels()` methods: calling these methods resets the counter value to zero.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ In general the author of this package would recommend instrumenting custom metri
 
 This package is intended as a way to publish metrics for applications that are _already_ instrumented with `go-metrics` without having to use a sidecar process like [stackdriver-prometheus-sidecar](https://github.com/Stackdriver/stackdriver-prometheus-sidecar).
 
+## 🚨 Upgrading
+
+Between v0.5.0 and v0.6.0, the behavior of the `IncrCounter` method changed: previously it would create a `GAUGE` [metric kind](https://cloud.google.com/monitoring/api/v3/kinds-and-types), but from v0.6.0 forward it will create a `CUMULATIVE` metric kind.  (See https://github.com/google/go-metrics-stackdriver/issues/18 for a discussion.)
+
+However, once a [MetricDescriptor](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics#MetricDescriptor) has been created in Google Cloud Monitoring, its `metricKind` field cannot be changed.  So if you have any _existing_ `GAUGE` metrics that were created by `IncrCounter`, you will see errors in your logs when the v0.6.0 client attempts to update them and fails.  Your options for handling this are:
+
+1. Change the name of the metric you are passing to `IncrCounter` (creating a new metricDescriptor with a different name), or:
+2. Delete the existing metricDescriptor using the [delete API](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors/delete) and let go-metrics re-create it as a `CUMULATIVE` metric
+
 ## Details
 
 [stackdriver.NewSink](https://godoc.org/github.com/google/go-metrics-stackdriver#NewSink)'s return value satisfies the go-metrics library's [MetricSink](https://godoc.org/github.com/armon/go-metrics#MetricSink) interface. When providing a `stackdriver.Sink` to libraries and applications instrumented against `MetricSink`, the metrics will be aggregated within this library and written to stackdriver as [Generic Task](https://cloud.google.com/monitoring/api/resources#tag_generic_task) timeseries metrics.

--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -365,7 +365,7 @@ func TestSample(t *testing.T) {
 								Metric: &metricpb.Metric{
 									Type: "custom.googleapis.com/go-metrics/foo_bar_counter",
 								},
-								MetricKind: metricpb.MetricDescriptor_GAUGE,
+								MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 								Points: []*monitoringpb.Point{
 									{
 										Value: &monitoringpb.TypedValue{
@@ -402,7 +402,7 @@ func TestSample(t *testing.T) {
 										"env": "dev",
 									},
 								},
-								MetricKind: metricpb.MetricDescriptor_GAUGE,
+								MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 								Points: []*monitoringpb.Point{
 									{
 										Value: &monitoringpb.TypedValue{
@@ -438,7 +438,7 @@ func TestSample(t *testing.T) {
 								Metric: &metricpb.Metric{
 									Type: "custom.googleapis.com/go-metrics/foo_bar_counter",
 								},
-								MetricKind: metricpb.MetricDescriptor_GAUGE,
+								MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 								Points: []*monitoringpb.Point{
 									{
 										Value: &monitoringpb.TypedValue{
@@ -773,7 +773,7 @@ func TestExtract(t *testing.T) {
 										"method": "bar",
 									},
 								},
-								MetricKind: metricpb.MetricDescriptor_GAUGE,
+								MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 								Points: []*monitoringpb.Point{
 									{
 										Value: &monitoringpb.TypedValue{
@@ -914,7 +914,7 @@ func TestExtract(t *testing.T) {
 										"method": "baz",
 									},
 								},
-								MetricKind: metricpb.MetricDescriptor_GAUGE,
+								MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 								Points: []*monitoringpb.Point{
 									{
 										Value: &monitoringpb.TypedValue{


### PR DESCRIPTION
This addresses https://github.com/google/go-metrics-stackdriver/issues/18

While using `|align delta_gauge()` in MQL is potentially a workaround, it suffers from the drawback of producing huge negative deltas when the counter resets, and the current behavior is unhappily surprising to first-time users who would reasonably assume that `IncrCounter()` would produce a CUMULATIVE metric.

Signed-off-by: Nathan J. Mehl <n@oden.io>